### PR TITLE
remove tsne

### DIFF
--- a/bin/compute_2dreps.py
+++ b/bin/compute_2dreps.py
@@ -1,5 +1,4 @@
 import scanpy as sc
-from tsnecuda import TSNE
 import pymde
 from utils import make_parents, wrap_kwargs
 
@@ -36,7 +35,6 @@ def compute_2dreps(
         adata.write_h5ad(adata_out)
 
     latent_pca_keys = []
-    latent_tsne_keys = []
     latent_mde_keys = []
     for latent_key in latent_keys:
         latent = adata.obsm[latent_key]
@@ -46,17 +44,11 @@ def compute_2dreps(
         adata.obsm[latent_pca_key] = latent_pca
         latent_pca_keys.append(latent_pca_key)
 
-        latent_tsne = TSNE(perplexity=30).fit_transform(latent)
-        latent_tsne_key = f"{latent_key}_tsne"
-        adata.obsm[latent_tsne_key] = latent_tsne
-        latent_tsne_keys.append(latent_tsne_key)
-
         latent_mde = pymde.preserve_neighbors(latent, **mde_kwargs).embed().cpu().numpy()
         latent_mde_key = f"{latent_key}_mde"
         adata.obsm[latent_mde_key] = latent_mde
         latent_mde_keys.append(latent_mde_key)
     adata.uns["latent_pca_keys"] = latent_pca_keys
-    adata.uns["latent_tsne_keys"] = latent_tsne_keys
     adata.uns["latent_mde_keys"] = latent_mde_keys
 
     adata.write_h5ad(adata_out)

--- a/env/gpu/compute_2dreps.yaml
+++ b/env/gpu/compute_2dreps.yaml
@@ -14,7 +14,6 @@ dependencies:
     - dask=2022.12.1
     - netcdf4=1.6.2
     - pymde=0.1.18
-    - tsnecuda
     - pip
     - pip:
           - click


### PR DESCRIPTION
Based on our discussion, it seems like `TSNECUDA` can cause OOM issues.
This PR removes all references to this package, and just pymde and pca are run as dimension reduction tools